### PR TITLE
Improve generator route comments

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -313,10 +313,12 @@ func updateRoutesFile(name string, actions []string) error {
 
 	indent := leadingWhitespace(lines[insertIdx])
 	ctrlVar := toCamelCase(name) + "Ctrl"
+	ctrlName := toCamelCase(name) + "Controller"
 	base := "/" + toSnakeCase(name)
 
 	var newLines []string
-	newLines = append(newLines, fmt.Sprintf("%s// %sController handles %s actions", indent, ctrlVar, name))
+	newLines = append(newLines, "")
+	newLines = append(newLines, fmt.Sprintf("%s// routes for %s", indent, ctrlName))
 	for _, act := range actions {
 		switch act {
 		case "index":


### PR DESCRIPTION
## Summary
- label sets of generated routes with controller-specific comments
- insert blank lines before and after each controller's routes for readability

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684cd8e4b270832e9d211c69fb17bb42