### PR TITLE
Add generator help output

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ main program:
 go run main.go generator <type> [...options]
 ```
 
-Supported types are `model`, `controller` and `resource`.
+Supported types are `model`, `controller`, `resource` and `authentication`.
 
 ### Model
 
@@ -427,6 +427,15 @@ go run main.go generator resource widget name:string price:int
 
 This creates the model, a `widgets` controller with all CRUD actions, placeholder
 tests and templates, and RESTful routes under `/widgets`.
+
+### Authentication
+
+```bash
+go run main.go generator authentication
+```
+
+Generates a basic user model, session management and routes for user signup,
+login and logout.
 
 ---
 

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -13,14 +13,33 @@ import (
 	"github.com/jinzhu/inflection"
 )
 
+const helpMessage = `Usage: go run main.go generator <command> [arguments]
+
+Available commands:
+  model NAME [field:type...]    Create a model struct and update db migrations
+  controller NAME [actions]     Create a controller, templates and routes
+  resource NAME [field:type...] Create model and full REST controller
+  authentication                Scaffold basic user authentication
+
+Examples:
+  go run main.go generator model Widget name:string price:int
+  go run main.go generator controller widgets index show
+  go run main.go generator resource widget name:string price:int
+  go run main.go generator authentication
+`
+
 // Run dispatches to the specific generator based on args.
 // args should not include the leading "generator" argument.
 func Run(args []string) error {
 	if len(args) == 0 {
+		fmt.Print(helpMessage)
 		return errors.New("missing generator type")
 	}
 
 	switch args[0] {
+	case "help":
+		fmt.Print(helpMessage)
+		return nil
 	case "model":
 		return runModel(args[1:])
 	case "controller":
@@ -30,6 +49,7 @@ func Run(args []string) error {
 	case "authentication":
 		return runAuthentication(args[1:])
 	default:
+		fmt.Print(helpMessage)
 		return fmt.Errorf("unknown generator: %s", args[0])
 	}
 }


### PR DESCRIPTION
## Summary
- show a detailed generator help message
- display help when the generator command is missing or invalid
- document the authentication generator in the README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684cf5e400c8832eb7cd2905f6528db3