### PR TITLE
Add admin generator

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -1498,16 +1498,23 @@ func updateRoutesForAdmin() error {
 		return fmt.Errorf("could not find insertion point in routes.go")
 	}
 	indent := leadingWhitespace(lines[insertIdx])
-	newLine := fmt.Sprintf("%smux.HandleFunc(\"GET /admin\", middleware.RequireAdmin(controllers.AdminCtrl.Dashboard))", indent)
-	exists := false
-	for _, l := range lines {
-		if strings.TrimSpace(l) == strings.TrimSpace(newLine) {
-			exists = true
-			break
-		}
+	newLines := []string{
+		fmt.Sprintf("%smux.HandleFunc(\"GET /admin\", middleware.RequireAdmin(controllers.AdminCtrl.Dashboard))", indent),
+		fmt.Sprintf("%smux.HandleFunc(\"POST /admin\", middleware.RequireAdmin(controllers.AdminCtrl.Dashboard))", indent),
 	}
-	if !exists {
-		lines = append(lines[:insertIdx], append([]string{newLine, ""}, lines[insertIdx:]...)...)
+
+	for _, nl := range newLines {
+		exists := false
+		for _, l := range lines {
+			if strings.TrimSpace(l) == strings.TrimSpace(nl) {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			lines = append(lines[:insertIdx], append([]string{nl}, lines[insertIdx:]...)...)
+			insertIdx++
+		}
 	}
 	out := strings.Join(lines, "\n")
 	formatted, err := format.Source([]byte(out))

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -293,7 +293,7 @@ func TestRunAdmin(t *testing.T) {
 		}
 	}
 	data, _ := os.ReadFile("routes/routes.go")
-	if !strings.Contains(string(data), "/admin") {
+	if !strings.Contains(string(data), "GET /admin") || !strings.Contains(string(data), "POST /admin") {
 		t.Fatalf("route not added: %s", string(data))
 	}
 }


### PR DESCRIPTION
## Summary
- extend generator with `admin` command
- scaffold admin controller, route, middleware and template
- create helper to fetch session email
- update routes to include `/admin`
- test new generator

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684e3df60728832e8873a440ea33642c