### PR TITLE
Add Makefile support for generators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,4 +25,15 @@ doc:
 deploy:
 	chmod +x ./server_management/deploy.sh && ./server_management/deploy.sh
 
-.PHONY: dev run build test deploy
+.PHONY: dev run build test deploy generator
+
+# Pass any additional arguments after "generator" through to the Go program
+ARGS := $(filter-out generator,$(MAKECMDGOALS))
+
+# Run a generator via `make generator <type> [options]`
+generator:
+	go run main.go generator $(ARGS)
+
+# Catch-all target so extra arguments don't raise errors
+%:
+	@:

--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ Import and call it from controllers or jobs – services keep business logic awa
 Use the generator to scaffold a job:
 
 ```bash
-go run main.go generator job Email
+make generator job Email
 ```
 
 This creates `jobs/email_job.go` with a stub `EmailJob` function, registers it
@@ -445,11 +445,13 @@ hub.Broadcast("notifications", []byte(`{"title":"Build finished"}`))
 
 ## Generators
 
-Generators scaffold common pieces of the application. They are run through the
-main program:
+Generators scaffold common pieces of the application. They can be run through
+the main program or via `make`:
 
 ```bash
 go run main.go generator <type> [...options]
+# or
+make generator <type> [...options]
 ```
 
 Supported types are `model`, `controller`, `resource`, `authentication` and `job`.
@@ -457,7 +459,7 @@ Supported types are `model`, `controller`, `resource`, `authentication` and `job
 ### Model
 
 ```bash
-go run main.go generator model Widget name:string price:int
+make generator model Widget name:string price:int
 ```
 
 Creates `models/widget.go` with a `Widget` struct and updates `db/db.go` so the
@@ -468,7 +470,7 @@ model is automatically migrated.
 Controllers are typically named using the plural form:
 
 ```bash
-go run main.go generator controller widgets index show
+make generator controller widgets index show
 ```
 
 This generates `controllers/widgets_controller.go`, inserts matching routes into
@@ -480,7 +482,7 @@ The resource generator produces a model and a full REST controller in one step.
 Pass the **singular** name; the controller and routes will be pluralised.
 
 ```bash
-go run main.go generator resource widget name:string price:int
+make generator resource widget name:string price:int
 ```
 
 This creates the model, a `widgets` controller with all CRUD actions, placeholder
@@ -489,7 +491,7 @@ tests and templates, and RESTful routes under `/widgets`.
 ### Authentication
 
 ```bash
-go run main.go generator authentication
+make generator authentication
 ```
 
 Generates a basic user model, session management and routes for user signup,
@@ -498,7 +500,7 @@ login and logout.
 ### Job
 
 ```bash
-go run main.go generator job MyJob
+make generator job MyJob
 ```
 
 Creates `jobs/my_job_job.go` with a stub `MyJobJob` function, registers it in

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -14,6 +14,7 @@ import (
 )
 
 const helpMessage = `Usage: go run main.go generator <command> [arguments]
+   or: make generator <command> [arguments]
 
 Available commands:
   model NAME [field:type...]    Create a model struct and update db migrations
@@ -24,11 +25,11 @@ Available commands:
   admin                         Add an admin dashboard with profiling helpers
 
 Examples:
-  go run main.go generator model Widget name:string price:int
-  go run main.go generator controller widgets index show
-  go run main.go generator resource widget name:string price:int
-  go run main.go generator authentication
-  go run main.go generator job MyJob
+  make generator model Widget name:string price:int
+  make generator controller widgets index show
+  make generator resource widget name:string price:int
+  make generator authentication
+  make generator job MyJob
 `
 
 // Run dispatches to the specific generator based on args.

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -6,7 +6,7 @@ are registered in `jobs/job_queue.go`.
 
 Use the generator to scaffold a new job:
 
-	go run main.go generator job Email
+        make generator job Email
 
 The generator creates `jobs/email_job.go` with a stub `EmailJob` function,
 adds a matching `JobTypeEmail` enum and registers it with the job queue for you.


### PR DESCRIPTION
## Summary
- add `generator` target to Makefile for running code generators
- document usage of `make generator` in README and generator help
- adjust job queue comment for new generator usage

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685376b50cf8832eb31bff252b3d686f