### PR TITLE
Fix deploy target to require host argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,15 @@ doc:
 	godoc -http=":6060"
 
 # Deploy using the deploy script
+DEPLOY_ARGS := $(filter-out deploy,$(MAKECMDGOALS))
+
+# Deploy using the deploy script
 deploy:
-	chmod +x ./server_management/deploy.sh && ./server_management/deploy.sh
+	@if [ -z "$(DEPLOY_ARGS)" ]; then \
+	echo "Usage: make deploy <user@host>"; \
+	exit 1; \
+	fi; \
+	chmod +x ./server_management/deploy.sh && ./server_management/deploy.sh $(DEPLOY_ARGS)
 
 
 # Pass any additional arguments after "generator" through to the Go program


### PR DESCRIPTION
## Summary
- ensure `deploy` target passes provided arguments to deploy script
- error out when no host argument is given

## Testing
- `go test ./...`
- `make deploy` *(fails: Usage message)*

------
https://chatgpt.com/codex/tasks/task_e_6855e6930488832eb8ff229b27af8d9e