### PR TITLE
Add validation hooks using log and update generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,25 @@ Example: Creating a user
 user, _ := models.CreateUser(db.GetDB(), "foo@example.com", "secret")
 ```
 
+#### Automatic validation
+
+Any model that implements the `Validatable` interface will have its `Validate`
+method called automatically before saving. The interface and generic hook live
+in `models/validation.go`:
+
+```go
+type Validatable interface {
+    Validate() error
+}
+
+func (m Validatable) BeforeSave(tx *gorm.DB) error {
+    return m.Validate()
+}
+```
+
+`Job` and `Message` implement this interface so attempts to persist them will
+fail if their fields are invalid.
+
 ### Sessions & Authentication
 
 Session helpers live in `session/session.go`:

--- a/models/validation.go
+++ b/models/validation.go
@@ -1,0 +1,16 @@
+package models
+
+import "gorm.io/gorm"
+
+// Validatable is implemented by models that can validate themselves.
+type Validatable interface {
+	Validate() error
+}
+
+// beforeSave is a helper that runs Validate on the given model.
+func beforeSave(m any, tx *gorm.DB) error {
+	if v, ok := m.(Validatable); ok {
+		return v.Validate()
+	}
+	return nil
+}

--- a/models/ws.go
+++ b/models/ws.go
@@ -1,6 +1,13 @@
 package models
 
-import "time"
+import (
+	"errors"
+	"log"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+)
 
 // Message is the GORM model used to store incoming messages used by web sockets.
 type Message struct {
@@ -8,4 +15,22 @@ type Message struct {
 	Channel   string
 	Content   string
 	CreatedAt time.Time
+}
+
+// Validate ensures required message fields are populated.
+func (m *Message) Validate() error {
+	if strings.TrimSpace(m.Channel) == "" {
+		log.Print("channel required")
+		return errors.New("channel required")
+	}
+	if strings.TrimSpace(m.Content) == "" {
+		log.Print("content required")
+		return errors.New("content required")
+	}
+	return nil
+}
+
+// BeforeSave calls Validate before persisting the Message.
+func (m *Message) BeforeSave(tx *gorm.DB) error {
+	return beforeSave(m, tx)
 }


### PR DESCRIPTION
## Summary
- switch validation code to log errors instead of fmt
- generate models with placeholder Validate and BeforeSave
- ensure generated User model validates before saving

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68577e6b37a0832e8bca3312f7c9b077