### PR TITLE
Add blank GORM hooks to generated models

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,10 @@ gorm.Open(postgres.Open(os.Getenv("DATABASE_URL")), &gorm.Config{})
 
 All models embed GORM timestamps, so you automatically get `CreatedAt` / `UpdatedAt`.
 
+Generated models also include blank `BeforeSave` and `AfterSave` hooks. GORM
+automatically invokes these methods before and after a record is persisted, so
+you can implement validation or post‑processing logic as needed.
+
 Example: Creating a user
 
 ```go
@@ -506,7 +510,9 @@ make generator model Widget name:string price:int
 ```
 
 Creates `models/widget.go` with a `Widget` struct and updates `db/db.go` so the
-model is automatically migrated.
+model is automatically migrated. The file also defines empty `BeforeSave` and
+`AfterSave` hooks which you can use to validate your model before and after it
+is saved.
 
 ### Controller
 

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -322,7 +322,8 @@ func createModelFile(modelName string, fields []string) error {
 	var buf bytes.Buffer
 	buf.WriteString("package models\n\n")
 	buf.WriteString("import \"gorm.io/gorm\"\n\n")
-	buf.WriteString(fmt.Sprintf("type %s struct {\n", toCamelCase(modelName)))
+	camelName := toCamelCase(modelName)
+	buf.WriteString(fmt.Sprintf("type %s struct {\n", camelName))
 	buf.WriteString("\tgorm.Model\n")
 
 	for _, f := range fields {
@@ -334,6 +335,19 @@ func createModelFile(modelName string, fields []string) error {
 		}
 		buf.WriteString(fmt.Sprintf("\t%s %s\n", toCamelCase(name), typ))
 	}
+	buf.WriteString("}\n\n")
+
+	// add blank hook implementations so users can customize validations
+	buf.WriteString(fmt.Sprintf("// BeforeSave is called by GORM before persisting a %s.\n", camelName))
+	buf.WriteString("// Use this hook to validate or modify the model before saving.\n")
+	buf.WriteString(fmt.Sprintf("func (m *%s) BeforeSave(tx *gorm.DB) error {\n", camelName))
+	buf.WriteString("\treturn nil\n")
+	buf.WriteString("}\n\n")
+
+	buf.WriteString(fmt.Sprintf("// AfterSave is triggered by GORM after a %s has been saved.\n", camelName))
+	buf.WriteString("// This can be used for post-save actions or additional validation.\n")
+	buf.WriteString(fmt.Sprintf("func (m *%s) AfterSave(tx *gorm.DB) error {\n", camelName))
+	buf.WriteString("\treturn nil\n")
 	buf.WriteString("}\n")
 
 	formatted, err := format.Source(buf.Bytes())


### PR DESCRIPTION
## Summary
- include BeforeSave and AfterSave hooks in created models
- document the new hooks in the README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68578ddf6d60832eb4734d53cd6c54f3