### PR TITLE
Add BeforeSave/AfterSave hooks to generated user model

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -719,6 +719,18 @@ type User struct {
     IsAdmin      bool ` + "`gorm:\"default:false\"`" + `
 }
 
+// BeforeSave is called by GORM before persisting a User.
+// Use this hook to validate or modify the model before saving.
+func (u *User) BeforeSave(tx *gorm.DB) error {
+    return nil
+}
+
+// AfterSave is triggered by GORM after a User has been saved.
+// This can be used for post-save actions or additional validation.
+func (u *User) AfterSave(tx *gorm.DB) error {
+    return nil
+}
+
 // GetUser fetches a user by email from the database
 func GetUser(db *gorm.DB, email string) (*User, error) {
     var user User

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -267,6 +267,10 @@ func TestRunAuthentication(t *testing.T) {
 	if !strings.Contains(string(db), "&models.User{}") {
 		t.Fatalf("db not updated: %s", string(db))
 	}
+	userModel, _ := os.ReadFile("models/user.go")
+	if !strings.Contains(string(userModel), "BeforeSave") || !strings.Contains(string(userModel), "AfterSave") {
+		t.Fatalf("hooks not added: %s", string(userModel))
+	}
 }
 
 func TestRunAdmin(t *testing.T) {


### PR DESCRIPTION
## Summary
- include blank hooks when creating the user model in authentication generator
- verify hooks in TestRunAuthentication

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6857914be3d8832eb1dc99221a31691a