### PR TITLE
Rename auth templates

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -1058,10 +1058,10 @@ func createAuthControllerFile() error {
 	buf.WriteString("type AuthController struct{}\n\n")
 	buf.WriteString("var AuthCtrl = &AuthController{}\n\n")
 	buf.WriteString("func (ac *AuthController) ShowLoginForm(w http.ResponseWriter, r *http.Request) {\n")
-	buf.WriteString("\tviews.Render(w, \"login.html.tmpl\", nil)\n")
+	buf.WriteString("\tviews.Render(w, \"auth_login.html.tmpl\", nil)\n")
 	buf.WriteString("}\n\n")
 	buf.WriteString("func (ac *AuthController) ShowSignupForm(w http.ResponseWriter, r *http.Request) {\n")
-	buf.WriteString("\tviews.Render(w, \"signup.html.tmpl\", nil)\n")
+	buf.WriteString("\tviews.Render(w, \"auth_signup.html.tmpl\", nil)\n")
 	buf.WriteString("}\n\n")
 	buf.WriteString("func (ac *AuthController) Signup(w http.ResponseWriter, r *http.Request) {\n")
 	buf.WriteString("\tif err := r.ParseForm(); err != nil {\n")
@@ -1112,7 +1112,7 @@ func createAuthControllerFile() error {
 
 // createLoginTemplate generates a basic login template.
 func createLoginTemplate() error {
-	path := filepath.Join("views", "login.html.tmpl")
+	path := filepath.Join("views", "auth_login.html.tmpl")
 	if _, err := os.Stat(path); err == nil {
 		fmt.Println("exists", path)
 		return nil
@@ -1160,7 +1160,7 @@ func createLoginTemplate() error {
 }
 
 func createSignupTemplate() error {
-	path := filepath.Join("views", "signup.html.tmpl")
+	path := filepath.Join("views", "auth_signup.html.tmpl")
 	if _, err := os.Stat(path); err == nil {
 		fmt.Println("exists", path)
 		return nil

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -251,8 +251,8 @@ func TestRunAuthentication(t *testing.T) {
 		"middleware/auth.go",
 		"middleware/auth_test.go",
 		"controllers/auth_controller.go",
-		"views/login.html.tmpl",
-		"views/signup.html.tmpl",
+		"views/auth_login.html.tmpl",
+		"views/auth_signup.html.tmpl",
 	}
 	for _, f := range files {
 		if _, err := os.Stat(f); err != nil {


### PR DESCRIPTION
## Summary
- update authentication scaffolding to generate `auth_login.html.tmpl` and `auth_signup.html.tmpl`
- adjust generator tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6858487d6aec832e8d2fa58a8ab2757a