### PR TITLE
Log response status in middleware

### DIFF
--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"fmt"
 	"log/slog"
 	"net/http"
 	"time"
@@ -10,7 +11,11 @@ import (
 func LoggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
-		next.ServeHTTP(w, r)
+
+		// Wrap the ResponseWriter to capture the status code
+		rw := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+
+		next.ServeHTTP(rw, r)
 
 		// Use the globally configured slog logger
 		slog.Info("HTTP Request",
@@ -18,7 +23,19 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 			"path", r.URL.Path,
 			"remoteAddr", r.RemoteAddr,
 			"userAgent", r.UserAgent(),
+			"status", fmt.Sprintf("%d %s", rw.status, http.StatusText(rw.status)),
 			"duration", time.Since(start),
 		)
 	})
+}
+
+// statusRecorder wraps http.ResponseWriter to record the status code written.
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	r.status = code
+	r.ResponseWriter.WriteHeader(code)
 }


### PR DESCRIPTION
## Summary
- capture HTTP response status in `LoggingMiddleware`
- log status alongside request details

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685a2a2b0490832e8dfd1d8494cac071