### PR TITLE
Fix logging to return 404 for unknown paths

### DIFF
--- a/controllers/ErrorController.go
+++ b/controllers/ErrorController.go
@@ -1,0 +1,16 @@
+package controllers
+
+import (
+	"monolith/views"
+	"net/http"
+)
+
+type ErrorController struct{}
+
+var ErrorCtrl = &ErrorController{}
+
+// Show404 renders the 404 page with a 404 status code.
+func (ec *ErrorController) Show404(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotFound)
+	views.Render(w, "404.html.tmpl", nil)
+}

--- a/controllers/IndexController.go
+++ b/controllers/IndexController.go
@@ -12,6 +12,12 @@ var IndexCtrl = &IndexController{}
 
 // ShowIndex renders the index page
 func (ic *IndexController) ShowIndex(w http.ResponseWriter, r *http.Request) {
+	// Only respond to the exact root path. Anything else should be a 404.
+	if r.URL.Path != "/" {
+		ErrorCtrl.Show404(w, r)
+		return
+	}
+
 	data := map[string]interface{}{
 		"monolith_version": config.MONOLITH_VERSION,
 	}

--- a/views/404.html.tmpl
+++ b/views/404.html.tmpl
@@ -1,0 +1,8 @@
+{{template "base.html.tmpl" .}}
+
+{{define "title"}}<title>Page Not Found</title>{{end}}
+
+{{define "body"}}
+<h1>404 - Page Not Found</h1>
+<p>The page you requested could not be found.</p>
+{{end}}


### PR DESCRIPTION
## Summary
- add a 404 error template
- add an `ErrorController` to render the 404 page
- only show index on the root path; otherwise render 404

## Testing
- `go test ./... -p 1`


------
https://chatgpt.com/codex/tasks/task_e_685a2f5c4eb8832e94a8a70e743576e7