### PR TITLE
Add 404 route test

### DIFF
--- a/routes/routes_test.go
+++ b/routes/routes_test.go
@@ -1,0 +1,22 @@
+package routes
+
+import (
+	"embed"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRandomRouteNotFound(t *testing.T) {
+	// zero-value embed.FS provides an empty filesystem for static files
+	handler := InitServerHandler(embed.FS{})
+
+	req := httptest.NewRequest(http.MethodGet, "/does-not-exist", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusNotFound {
+		t.Fatalf("expected status 404, got %d", w.Result().StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary
- add a routes test verifying that unknown paths return a 404

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685a3407dae8832e81c78211a7ed38d9