### PR TITLE
Update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,7 @@ This will do a zero downtime deploy by calling,
 ```bash
 ./server_management/deploy.sh
 ```
+By default the script prunes old releases after deployment. Set `PRUNE=false` to skip pruning.
 
 ---
 
@@ -649,6 +650,6 @@ This will do a zero downtime deploy by calling,
 | `make build` | Build a statically linked binary |
 | `make run`   | `go run ./...` |
 | `make test`  | `go test ./...` |
-| `make deploy`|
+| `make deploy`| Zero downtime deploy via server_management/deploy.sh
 
 ---

--- a/server_management/README.md
+++ b/server_management/README.md
@@ -1,5 +1,8 @@
 # 1. One‑time server bootstrap
-./server_setup.sh ubuntu@203.0.113.5
+./server_setup.sh ubuntu@203.0.113.5 example.com
 
 # 2. Any time you have new code
 ./deploy.sh ubuntu@203.0.113.5
+By default deploy.sh prunes old releases after deployment. Set `PRUNE=false` to keep all past releases.
+PRUNE=false ./deploy.sh ubuntu@203.0.113.5
+

--- a/ws/README.md
+++ b/ws/README.md
@@ -30,4 +30,4 @@ You can test the server using a WebSocket client. For example, you can send the 
    The `/ws` HTTP endpoint upgrades HTTP connections to WebSocket connections using gorilla/websocket.
 
 5. **Running the Server:**  
-   Finally, the server listens on port 8080.
+   Finally, the server listens on port 9000 by default (configurable via `BIN_PORT`).


### PR DESCRIPTION
## Summary
- document pruning behavior in deployment docs
- clarify server setup example and deployment pruning
- fix websocket docs to mention default port

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685b769481e4832e9a73bfdf06199a4e