### PR TITLE
Add optional litestream installation

### DIFF
--- a/server_management/README.md
+++ b/server_management/README.md
@@ -1,5 +1,6 @@
 # 1. One‑time server bootstrap
 `./server_setup.sh ubuntu@203.0.113.5 example.com`
+Optional: pass `--no-litestream` to skip installing [Litestream](https://github.com/benbjohnson/litestream).
 
 # 2. Any time you have new code
 `./deploy.sh ubuntu@203.0.113.5`


### PR DESCRIPTION
## Summary
- update server_setup.sh to optionally install Litestream
- document the --no-litestream flag in server_management README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685c9c1ee560832eaed9989e274a7092