### PR TITLE
Switch to slog for printf logging

### DIFF
--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -6,7 +6,7 @@ are registered in `jobs/job_queue.go`.
 
 Use the generator to scaffold a new job:
 
-        make generator job Email
+	make generator job Email
 
 The generator creates `jobs/email_job.go` with a stub `EmailJob` function,
 adds a matching `JobTypeEmail` enum and registers it with the job queue for you.
@@ -15,7 +15,7 @@ package jobs
 
 import (
 	"encoding/json"
-	"log"
+	"log/slog"
 )
 
 // printJob is an example job function that expects a JSON payload with a "message" field.
@@ -26,7 +26,7 @@ func PrintJob(payload string) error {
 	if err := json.Unmarshal([]byte(payload), &data); err != nil {
 		return err
 	}
-	log.Printf("printJob: %s", data.Message)
+	slog.Info("printJob", "message", data.Message)
 	return nil
 }
 

--- a/server_management/server_management.go
+++ b/server_management/server_management.go
@@ -28,13 +28,13 @@ func RunServer(staticFiles embed.FS) {
 	var ln net.Listener
 	if err == nil && len(listeners) > 0 {
 		ln = listeners[0]
-		log.Printf("using systemd listener on %s", ln.Addr())
+		slog.Info("using systemd listener", "addr", ln.Addr())
 	} else {
 		ln, err = net.Listen("tcp", "127.0.0.1:"+config.PORT)
 		if err != nil {
 			log.Fatalf("listen: %v", err)
 		}
-		log.Printf("socket activation unavailable, listening on %s", ln.Addr())
+		slog.Info("socket activation unavailable", "addr", ln.Addr())
 	}
 
 	slog.Info("Starting server", "address", ":"+config.PORT)
@@ -57,18 +57,18 @@ func RunServer(staticFiles embed.FS) {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		if err := server.Shutdown(ctx); err != nil {
-			log.Printf("HTTP shutdown: %v", err)
+			slog.Error("HTTP shutdown", "error", err)
 		}
 		close(idleConnsClosed)
 	}()
 
-	log.Printf("serving HTTP")
+	slog.Info("serving HTTP")
 	if err := server.Serve(ln); err != http.ErrServerClosed {
 		log.Fatalf("Serve: %v", err)
 	}
 
 	<-idleConnsClosed
-	log.Printf("goodbye")
+	slog.Info("goodbye")
 }
 
 // sdListeners returns the list of sockets passed by systemd via LISTEN_FDS.


### PR DESCRIPTION
## Summary
- replace `log.Printf` with `slog.Info` or `slog.Error`
- drop unused `log` imports

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685e2fd06f00832ea3b07eced5e6a0bf