### PR TITLE
Fix safari login cookie handling

### DIFF
--- a/csrf/csrf.go
+++ b/csrf/csrf.go
@@ -32,6 +32,7 @@ func ensureToken(w http.ResponseWriter, r *http.Request) string {
 		Value:    token,
 		Path:     "/",
 		HttpOnly: true,
+		Secure:   r.TLS != nil,
 		SameSite: http.SameSiteLaxMode,
 	})
 	return token

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -889,7 +889,7 @@ func createSessionFile() error {
 	buf.WriteString("}\n\n")
 	buf.WriteString("func SetLoggedIn(w http.ResponseWriter, r *http.Request, email string) {\n")
 	buf.WriteString("\tsession, _ := GetSession(r)\n")
-	buf.WriteString("\tsession.Options = &sessions.Options{MaxAge: 7 * 24 * 60 * 60, SameSite: http.SameSiteLaxMode}\n")
+	buf.WriteString("\tsession.Options = &sessions.Options{MaxAge: 7 * 24 * 60 * 60, SameSite: http.SameSiteLaxMode, Secure: r.TLS != nil}\n")
 	buf.WriteString("\tsession.Values[LOGGED_IN_KEY] = true\n")
 	buf.WriteString("\tsession.Values[EMAIL_KEY] = email\n")
 	buf.WriteString("\tsession.Save(r, w)\n")


### PR DESCRIPTION
## Summary
- secure CSRF cookie when HTTPS is used
- secure login session cookies generated by the auth scaffolding

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6861888ea92c832eb29b71d802fac0c2