### PR TITLE
Add session login/logout helpers and tests

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -22,3 +22,27 @@ func InitSession() {
 func GetSession(r *http.Request) (*sessions.Session, error) {
 	return store.Get(r, SESSION_NAME_KEY)
 }
+
+// SetLoggedIn marks the session as logged in and stores the email
+func SetLoggedIn(w http.ResponseWriter, r *http.Request, email string) {
+	session, _ := GetSession(r)
+	session.Options = &sessions.Options{MaxAge: 7 * 24 * 60 * 60, SameSite: http.SameSiteLaxMode, Secure: r.TLS != nil}
+	session.Values[LOGGED_IN_KEY] = true
+	session.Values[EMAIL_KEY] = email
+	session.Save(r, w)
+}
+
+// Logout clears login related session values
+func Logout(w http.ResponseWriter, r *http.Request) {
+	session, _ := GetSession(r)
+	delete(session.Values, LOGGED_IN_KEY)
+	delete(session.Values, EMAIL_KEY)
+	session.Save(r, w)
+}
+
+// IsLoggedIn checks if the request is associated with a logged in session
+func IsLoggedIn(r *http.Request) bool {
+	session, _ := GetSession(r)
+	loggedIn, ok := session.Values[LOGGED_IN_KEY].(bool)
+	return ok && loggedIn
+}

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -1,1 +1,32 @@
 package session
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"monolith/config"
+)
+
+func TestSessionLoginLogout(t *testing.T) {
+	config.InitConfig()
+	InitSession()
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	SetLoggedIn(w, req, "test@example.com")
+	cookie := w.Result().Cookies()[0]
+
+	req2 := httptest.NewRequest("GET", "/", nil)
+	req2.AddCookie(cookie)
+	if !IsLoggedIn(req2) {
+		t.Fatal("expected logged in")
+	}
+
+	w2 := httptest.NewRecorder()
+	Logout(w2, req2)
+	cookie2 := w2.Result().Cookies()[0]
+	req3 := httptest.NewRequest("GET", "/", nil)
+	req3.AddCookie(cookie2)
+	if IsLoggedIn(req3) {
+		t.Fatal("expected logged out")
+	}
+}


### PR DESCRIPTION
## Summary
- generate session.go by appending login/logout helpers rather than replacing existing file
- expose login and logout functions in session package
- restore session login/logout tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6861b936a0d0832eb861fcedfbb52f83