### PR TITLE
Update docs for latest project version

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ CRUD actions, templates and RESTful routes under `/widgets`.
 make generator authentication
 ```
 
-Adds a basic `User` model, login/logout handlers and middleware for sessions.
+Scaffolds a `User` model with session helpers, login & signup templates, and authentication middleware.
 
 ### Generating an admin dashboard
 
@@ -199,7 +199,7 @@ Everything dynamic (port and database DSN) is read from **environment variables*
 
 | Variable | Default | Used in |
 | -------- | ------- | ------- |
-| `BIN_PORT` | `9000` | HTTP listener |
+| `PORT` | `9000` | HTTP listener |
 | `LISTEN_FDS`, `LISTEN_PID` | – | systemd socket activation |
 
 ### Database Layer
@@ -320,7 +320,7 @@ http.ListenAndServe(":9000", handler)
 
 ### Routing & HTTP controllers
 
-All controllers are in `controllers/` and are wired inside `main.go` using the **new routing syntax** (Go 1.22+):
+All controllers are in `controllers/` and are wired inside `main.go` using the **new routing syntax** (Go 1.23+):
 
 ```go
 mux.HandleFunc("GET /", controllers.Home)
@@ -653,7 +653,7 @@ By default the script prunes old releases after deployment. Set `PRUNE=false` to
 
 | Name | Description | Default |
 | ---- | ----------- | ------- |
-| `BIN_PORT` | Fallback TCP port when not using socket activation | `9000` |
+| `PORT` | Fallback TCP port when not using socket activation | `9000` |
 | `DATABASE_URL` | Postgres DSN (if you switch drivers) | – |
 | `MAILGUN_DOMAIN` | Mailgun domain used for sending mail | – |
 | `MAILGUN_API_KEY` | Private API key for Mailgun | – |
@@ -667,6 +667,7 @@ By default the script prunes old releases after deployment. Set `PRUNE=false` to
 | `make build` | Build a statically linked binary |
 | `make run`   | `go run ./...` |
 | `make test`  | `go test ./...` |
+| `make clean` | Clear test cache |
 | `make deploy`| Zero downtime deploy via server_management/deploy.sh
 
 ---

--- a/views/index.html.tmpl
+++ b/views/index.html.tmpl
@@ -47,7 +47,7 @@
   <!-- framework & runtime info -->
   <ul>
     <li><strong>Monolith version:</strong> {{.monolith_version}}</li>
-    <li><strong>Go version:</strong> go1.22+</li>
+    <li><strong>Go version:</strong> go1.23+</li>
   </ul>
 
 {{end}}

--- a/ws/README.md
+++ b/ws/README.md
@@ -29,5 +29,5 @@ You can test the server using a WebSocket client. For example, you can send the 
 4. **WebSocket Upgrade:**  
    The `/ws` HTTP endpoint upgrades HTTP connections to WebSocket connections using gorilla/websocket.
 
-5. **Running the Server:**  
-   Finally, the server listens on port 9000 by default (configurable via `BIN_PORT`).
+5. **Running the Server:**
+   Finally, the server listens on port 9000 by default (configurable via `PORT`).


### PR DESCRIPTION
## Summary
- update README environment variable and generator docs
- update go version mention to 1.23
- note new `make clean` target
- fix ws README reference to PORT
- update index page template

## Testing
- `make test` *(fails: attempt to write a readonly database)*

------
https://chatgpt.com/codex/tasks/task_e_68622ac8f304832e8e68f4b779c3e330