### PR TITLE
Update view generation to use subdirectories

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -680,10 +680,14 @@ func updateRoutesFile(name string, actions []string) error {
 // createTemplateFiles generates HTML views for GET actions.
 func createTemplateFiles(name string, actions []string) error {
 	snake := toSnakeCase(name)
+	dir := filepath.Join("views", snake)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
 	for _, act := range actions {
 		switch act {
 		case "index", "show", "new", "edit":
-			file := filepath.Join("views", fmt.Sprintf("%s_%s.html.tmpl", snake, act))
+			file := filepath.Join(dir, fmt.Sprintf("%s_%s.html.tmpl", snake, act))
 			if _, err := os.Stat(file); err == nil {
 				fmt.Println("exists", file)
 				continue
@@ -1161,7 +1165,11 @@ func createAuthControllerFile() error {
 
 // createLoginTemplate generates a basic login template.
 func createLoginTemplate() error {
-	path := filepath.Join("views", "auth_login.html.tmpl")
+	dir := filepath.Join("views", "auth")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	path := filepath.Join(dir, "auth_login.html.tmpl")
 	if _, err := os.Stat(path); err == nil {
 		fmt.Println("exists", path)
 		return nil
@@ -1209,7 +1217,11 @@ func createLoginTemplate() error {
 }
 
 func createSignupTemplate() error {
-	path := filepath.Join("views", "auth_signup.html.tmpl")
+	dir := filepath.Join("views", "auth")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	path := filepath.Join(dir, "auth_signup.html.tmpl")
 	if _, err := os.Stat(path); err == nil {
 		fmt.Println("exists", path)
 		return nil
@@ -1776,7 +1788,11 @@ func createAdminControllerFile() error {
 }
 
 func createAdminTemplate() error {
-	path := filepath.Join("views", "admin_dashboard.html.tmpl")
+	dir := filepath.Join("views", "admin")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	path := filepath.Join(dir, "admin_dashboard.html.tmpl")
 	if _, err := os.Stat(path); err == nil {
 		fmt.Println("exists", path)
 		return nil

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -104,7 +104,7 @@ func registerRoutes(mux *http.ServeMux, staticFiles embed.FS) {
 	if _, err := os.Stat("controllers/widgets_controller.go"); err != nil {
 		t.Fatalf("controller file: %v", err)
 	}
-	if _, err := os.Stat("views/widgets_index.html.tmpl"); err != nil {
+	if _, err := os.Stat(filepath.Join("views", "widgets", "widgets_index.html.tmpl")); err != nil {
 		t.Fatalf("index template: %v", err)
 	}
 	data, _ := os.ReadFile("routes/routes.go")
@@ -243,8 +243,8 @@ func TestRunAuthentication(t *testing.T) {
 		"middleware/auth.go",
 		"middleware/auth_test.go",
 		"controllers/auth_controller.go",
-		"views/auth_login.html.tmpl",
-		"views/auth_signup.html.tmpl",
+		filepath.Join("views", "auth", "auth_login.html.tmpl"),
+		filepath.Join("views", "auth", "auth_signup.html.tmpl"),
 	}
 	for _, f := range files {
 		if _, err := os.Stat(f); err != nil {
@@ -285,7 +285,7 @@ func TestRunAdmin(t *testing.T) {
 	files := []string{
 		"models/user.go",
 		"controllers/admin_controller.go",
-		"views/admin_dashboard.html.tmpl",
+		filepath.Join("views", "admin", "admin_dashboard.html.tmpl"),
 		"middleware/admin.go",
 		"middleware/admin_test.go",
 		"session/email.go",

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 //go:embed static/*
 var staticFiles embed.FS
 
-//go:embed views/*.html.tmpl
+//go:embed views/**
 var templateFiles embed.FS
 
 func main() {


### PR DESCRIPTION
## Summary
- generate view templates inside a directory named after the controller
- embed all view subdirectories
- load templates recursively and map by filename
- update tests for new paths

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686808dc46d4832eb87620dceb9cfa13