### PR TITLE
Improve configuration guide

### DIFF
--- a/guides/config.html
+++ b/guides/config.html
@@ -25,7 +25,53 @@
         </div>
       </header>
       <div id="article-body" class="wrapper">
-        <p>The <code>app/config/</code> directory defines compile-time constants that are imported across the project. Settings such as <code>JOB_QUEUE_NUM_WORKERS</code> live here. Anything dynamic, like the port or database DSN, is read from environment variables in <code>main.go</code> or the relevant package.</p>
+        <p>The <code>app/config/</code> package is the central place for all configuration used throughout a Monolith application. It contains compile&#8209;time constants as well as values loaded from environment variables. The file <code>config.go</code> exposes these settings as package variables so that other packages can import them directly.</p>
+
+        <h2 id="structure">Structure</h2>
+        <p>Compile&#8209;time constants rarely change and are defined at the top of <code>config.go</code>. Environment specific values such as the TCP port or Mailgun credentials are read with <code>os.Getenv</code> so they can be supplied at runtime.</p>
+        <pre><code class="highlight go">var JOB_QUEUE_NUM_WORKERS = 4
+var PORT            = os.Getenv("PORT")
+var MAILGUN_DOMAIN  = os.Getenv("MAILGUN_DOMAIN")
+var MAILGUN_API_KEY = os.Getenv("MAILGUN_API_KEY")
+var SECRET_KEY      = os.Getenv("SECRET_KEY")
+</code></pre>
+
+        <h2 id="initialisation">Initialisation</h2>
+        <p>Call <code>config.InitConfig()</code> early in <code>main.go</code> to apply defaults and log warnings when required variables are missing. This function sets sensible fallbacks so the app can run in development without additional setup.</p>
+        <pre><code class="highlight go">func InitConfig() {
+    if SECRET_KEY == "" {
+        slog.Warn("SECRET_KEY is not set, using default value. This is insecure for production use.")
+        SECRET_KEY = "default_secret_key"
+    }
+    if PORT == "" {
+        slog.Info("PORT is not set, using default value: 9000")
+        PORT = "9000"
+    }
+}
+</code></pre>
+
+        <h2 id="generators">Using Generators</h2>
+        <p>The command line generators automatically wire new code to the configuration package. For example, running:</p>
+        <pre><code class="highlight console">$ make generator authentication</code></pre>
+        <p>creates session helpers that rely on <code>config.SECRET_KEY</code>:</p>
+        <pre><code class="highlight go">store = sessions.NewCookieStore([]byte(config.SECRET_KEY))</code></pre>
+        <p>Similarly, <code>make generator job Email</code> scaffolds a job that can use <code>MAILGUN_DOMAIN</code> and <code>MAILGUN_API_KEY</code> to send email.</p>
+
+        <h2 id="environment-variables">Environment Variables</h2>
+        <p>These variables influence the behaviour of the running application. Set them in the shell or your process manager before starting the server.</p>
+        <div class="table-wrapper"><table>
+          <thead><tr><th>Variable</th><th>Default</th><th>Description</th></tr></thead>
+          <tbody>
+            <tr><td>PORT</td><td>9000</td><td>HTTP listener port</td></tr>
+            <tr><td>DATABASE_URL</td><td>–</td><td>Postgres DSN when not using SQLite</td></tr>
+            <tr><td>MAILGUN_DOMAIN</td><td>–</td><td>Domain used for sending email</td></tr>
+            <tr><td>MAILGUN_API_KEY</td><td>–</td><td>Mailgun API key</td></tr>
+            <tr><td>SECRET_KEY</td><td>–</td><td>Key used to sign session cookies</td></tr>
+          </tbody>
+        </table></div>
+
+        <h2 id="impact">Impact on the App</h2>
+        <p>Configuration values affect many subsystems: the job queue uses <code>JOB_QUEUE_NUM_WORKERS</code> to determine worker concurrency, the web server binds to <code>PORT</code>, and email delivery requires the Mailgun variables. Changing any of these values requires restarting the binary so they are picked up on boot.</p>
       </div>
     </article>
   </main>


### PR DESCRIPTION
## Summary
- expand `config.html` with a thorough explanation of the configuration system
- include init example, generator usage and environment variable table

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6868c33f4c04832e9227f146178f47ef