### PR TITLE
Add IP rate limiting middleware

### DIFF
--- a/app/config/config.go
+++ b/app/config/config.go
@@ -8,6 +8,7 @@ package config
 import (
 	"log/slog"
 	"os"
+	"strconv"
 )
 
 var JOB_QUEUE_NUM_WORKERS = 4
@@ -27,6 +28,8 @@ var SECRET_KEY = os.Getenv("SECRET_KEY")
 
 var MONOLITH_VERSION = "0.1.0"
 
+var RATE_LIMIT_REQUESTS_PER_MINUTE = 60
+
 func InitConfig() {
 	// log warnings if secret key and other environment variables are not set
 	if SECRET_KEY == "" {
@@ -42,5 +45,15 @@ func InitConfig() {
 	}
 	if MAILGUN_API_KEY == "" {
 		slog.Warn("MAILGUN_API_KEY is not set, email functionality will not function properly.")
+	}
+
+	if rl := os.Getenv("RATE_LIMIT_REQUESTS_PER_MINUTE"); rl != "" {
+		if v, err := strconv.Atoi(rl); err == nil {
+			RATE_LIMIT_REQUESTS_PER_MINUTE = v
+		} else {
+			slog.Warn("invalid RATE_LIMIT_REQUESTS_PER_MINUTE, using default", "error", err)
+		}
+	} else {
+		slog.Info("RATE_LIMIT_REQUESTS_PER_MINUTE is not set, using default value", "value", RATE_LIMIT_REQUESTS_PER_MINUTE)
 	}
 }

--- a/app/middleware/logging.go
+++ b/app/middleware/logging.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"time"
 )
@@ -18,10 +19,15 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 		next.ServeHTTP(rw, r)
 
 		// Use the globally configured slog logger
+		ip, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			ip = r.RemoteAddr
+		}
+
 		slog.Info("HTTP Request",
 			"method", r.Method,
 			"path", r.URL.Path,
-			"remoteAddr", r.RemoteAddr,
+			"ip", ip,
 			"userAgent", r.UserAgent(),
 			"status", fmt.Sprintf("%d %s", rw.status, http.StatusText(rw.status)),
 			"duration", time.Since(start).Milliseconds(),

--- a/app/middleware/rate_limit.go
+++ b/app/middleware/rate_limit.go
@@ -1,0 +1,75 @@
+package middleware
+
+import (
+	"log/slog"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+
+	"monolith/app/config"
+)
+
+// visitor tracks a client's rate limiter and last seen time.
+type visitor struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+var visitors = struct {
+	sync.Mutex
+	m map[string]*visitor
+}{m: make(map[string]*visitor)}
+
+func getVisitor(ip string) *rate.Limiter {
+	visitors.Lock()
+	defer visitors.Unlock()
+
+	v, exists := visitors.m[ip]
+	if !exists {
+		v = &visitor{
+			limiter:  rate.NewLimiter(rate.Every(time.Minute/time.Duration(config.RATE_LIMIT_REQUESTS_PER_MINUTE)), config.RATE_LIMIT_REQUESTS_PER_MINUTE),
+			lastSeen: time.Now(),
+		}
+		visitors.m[ip] = v
+	}
+	v.lastSeen = time.Now()
+	return v.limiter
+}
+
+// cleanupVisitors runs periodically and removes entries that haven't been seen for a while.
+func cleanupVisitors() {
+	for {
+		time.Sleep(time.Minute)
+		visitors.Lock()
+		for ip, v := range visitors.m {
+			if time.Since(v.lastSeen) > 3*time.Minute {
+				delete(visitors.m, ip)
+			}
+		}
+		visitors.Unlock()
+	}
+}
+
+func init() {
+	go cleanupVisitors()
+}
+
+// RateLimitMiddleware limits the number of requests an IP can make per minute.
+func RateLimitMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ip, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			ip = r.RemoteAddr
+		}
+		limiter := getVisitor(ip)
+		if !limiter.Allow() {
+			slog.Warn("rate limit exceeded", "ip", ip, "path", r.URL.Path)
+			http.Error(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/app/middleware/rate_limit_test.go
+++ b/app/middleware/rate_limit_test.go
@@ -1,0 +1,49 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"monolith/app/config"
+)
+
+func TestRateLimitMiddleware(t *testing.T) {
+	// Set small limit for test
+	old := config.RATE_LIMIT_REQUESTS_PER_MINUTE
+	config.RATE_LIMIT_REQUESTS_PER_MINUTE = 2
+	defer func() { config.RATE_LIMIT_REQUESTS_PER_MINUTE = old }()
+
+	h := RateLimitMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "1.2.3.4:1234"
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Result().StatusCode)
+	}
+
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Result().StatusCode)
+	}
+
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Result().StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", w.Result().StatusCode)
+	}
+
+	// After a minute, should allow again
+	time.Sleep(time.Minute)
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 after reset, got %d", w.Result().StatusCode)
+	}
+}

--- a/app/routes/routes.go
+++ b/app/routes/routes.go
@@ -15,9 +15,10 @@ func InitServerHandler(staticFiles embed.FS) http.Handler {
 	// Register all routes
 	registerRoutes(mux, staticFiles)
 
-	// Wrap with structured logging and CSRF protection middleware
+	// Wrap with logging, rate limiting, and CSRF protection middleware
 	loggedRouter := middleware.LoggingMiddleware(mux)
-	csrfProtected := middleware.CSRFMiddleware(loggedRouter)
+	rateLimited := middleware.RateLimitMiddleware(loggedRouter)
+	csrfProtected := middleware.CSRFMiddleware(rateLimited)
 
 	return csrfProtected
 }

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,15 @@
 module monolith
 
-go 1.23
+go 1.23.0
 
-toolchain go1.23.5
+toolchain go1.24.3
 
 require (
 	github.com/glebarez/sqlite v1.11.0
 	github.com/gorilla/sessions v1.4.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/jinzhu/inflection v1.0.0
-	golang.org/x/crypto v0.12.0
+	golang.org/x/time v0.12.0
 	gorm.io/gorm v1.25.12
 )
 

--- a/go.sum
+++ b/go.sum
@@ -25,13 +25,13 @@ github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
-golang.org/x/crypto v0.12.0 h1:tFM/ta59kqch6LlvYnPa0yx5a83cL2nHflFhYKvv9Yk=
-golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98yw=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
 golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
+golang.org/x/time v0.12.0 h1:ScB/8o8olJvc+CQPWrK3fPZNfh7qgwCrY0zJmoEQLSE=
+golang.org/x/time v0.12.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
 gorm.io/gorm v1.25.12 h1:I0u8i2hWQItBq1WfE0o2+WuL9+8L21K9e2HHSTE/0f8=
 gorm.io/gorm v1.25.12/go.mod h1:xh7N7RHfYlNc5EmcI/El95gXusucDrQnHXe0+CgWcLQ=
 modernc.org/libc v1.22.5 h1:91BNch/e5B0uPbJFgqbxXuOnxBQjlS//icfQEGmvyjE=


### PR DESCRIPTION
## Summary
- configure RATE_LIMIT_REQUESTS_PER_MINUTE in config
- log IP addresses in logging middleware
- add rate limiting middleware using golang.org/x/time/rate
- apply rate limiting after logging in the middleware chain
- update dependencies
- add tests for rate limiting

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_686a9eee9c74832ea51bd2a8c8bc1e31