### PR TITLE
Add hello endpoint

### DIFF
--- a/app/controllers/hello_controller.go
+++ b/app/controllers/hello_controller.go
@@ -1,0 +1,24 @@
+package controllers
+
+import (
+	"log/slog"
+	"monolith/db"
+	"net/http"
+)
+
+// HelloController handles the /hello route
+// It executes a simple database query and then writes Hello World.
+type HelloController struct{}
+
+// HelloCtrl is the shared instance used by routes.
+var HelloCtrl = &HelloController{}
+
+// Greet queries the database and responds with a greeting.
+func (hc *HelloController) Greet(w http.ResponseWriter, r *http.Request) {
+	if d := db.GetDB(); d != nil {
+		if err := d.Exec("SELECT 1").Error; err != nil {
+			slog.Error("db error", "error", err)
+		}
+	}
+	_, _ = w.Write([]byte("Hello World"))
+}

--- a/app/routes/routes.go
+++ b/app/routes/routes.go
@@ -28,6 +28,7 @@ func registerRoutes(mux *http.ServeMux, staticFiles embed.FS) {
 	mux.Handle("GET /static/", staticFileServer)
 
 	mux.HandleFunc("GET /", controllers.IndexCtrl.ShowIndex)
+	mux.HandleFunc("GET /hello", controllers.HelloCtrl.Greet)
 
 	// serve websockets routes at "/ws" endpoint
 	mux.HandleFunc("GET /ws", func(w http.ResponseWriter, r *http.Request) {

--- a/app/routes/routes_test.go
+++ b/app/routes/routes_test.go
@@ -20,3 +20,19 @@ func TestRandomRouteNotFound(t *testing.T) {
 		t.Fatalf("expected status 404, got %d", w.Result().StatusCode)
 	}
 }
+
+func TestHelloEndpoint(t *testing.T) {
+	handler := InitServerHandler(embed.FS{})
+
+	req := httptest.NewRequest(http.MethodGet, "/hello", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Result().StatusCode)
+	}
+	if w.Body.String() != "Hello World" {
+		t.Fatalf("expected body 'Hello World', got %q", w.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- add HelloController with DB query and greeting
- wire /hello route
- test new endpoint

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688cf73378e0832e97589d7dc51157d3